### PR TITLE
feat: Support ts as time field

### DIFF
--- a/internal/pkg/source/entry_test.go
+++ b/internal/pkg/source/entry_test.go
@@ -44,6 +44,14 @@ func TestParseLogEntry(t *testing.T) {
 			assert.Equal(t, "1", logEntry.Time)
 		},
 	}, {
+		Name: "ts_number",
+		JSON: `{"ts":1}`,
+		Assert: func(tb testing.TB, logEntry source.LogEntry) {
+			tb.Helper()
+
+			assert.Equal(t, "1", logEntry.Time)
+		},
+	}, {
 		Name: "time_text",
 		JSON: `{"time":"1970-01-01T00:00:00.00"}`,
 		Assert: func(tb testing.TB, logEntry source.LogEntry) {
@@ -54,6 +62,14 @@ func TestParseLogEntry(t *testing.T) {
 	}, {
 		Name: "timestamp_text",
 		JSON: `{"timestamp":"1970-01-01T00:00:00.00"}`,
+		Assert: func(tb testing.TB, logEntry source.LogEntry) {
+			tb.Helper()
+
+			assert.Equal(t, "1970-01-01T00:00:00.00", logEntry.Time)
+		},
+	}, {
+		Name: "ts_text",
+		JSON: `{"ts":"1970-01-01T00:00:00.00"}`,
 		Assert: func(tb testing.TB, logEntry source.LogEntry) {
 			tb.Helper()
 

--- a/internal/pkg/source/helper.go
+++ b/internal/pkg/source/helper.go
@@ -8,7 +8,7 @@ import (
 )
 
 func extractTime(value *fastjson.Value) string {
-	timeValue := extractValue(value, "timestamp", "time", "t")
+	timeValue := extractValue(value, "timestamp", "time", "t", "ts")
 	if timeValue != "" {
 		return formatMessage(strings.TrimSpace(timeValue))
 	}


### PR DESCRIPTION
## Description

This pull request adds support for the 'ts' field in addition to 'timestamp', 'time', and 't' as valid time fields when extracting time values from JSON data.


## Changes Made

- Modified the `extractTime` function to recognize 'ts' as a valid time field.
- Updated unit tests to account for the new time field.