### PR TITLE
fix: correct jlv config read from the home directory

### DIFF
--- a/cmd/jlv/main.go
+++ b/cmd/jlv/main.go
@@ -47,7 +47,7 @@ func readConfig() (*config.Config, error) {
 	}
 
 	homeDir, err := os.UserHomeDir()
-	if err != nil {
+	if err == nil {
 		paths = append(paths, path.Join(homeDir, configFileName))
 	}
 


### PR DESCRIPTION
Hello, I've fixed incorrect condition on successful home directory retrieval so that config files in home directory are not ignored.

Fixes #49 