### PR TITLE
perf(#64): optimize memory and CPU usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ vendor/
 
 # Config
 .jlv.jsonc
+
+## Logs
+/*.log

--- a/example.jlv.jsonc
+++ b/example.jlv.jsonc
@@ -66,8 +66,8 @@
     // The number of rows to pre-render.
     "prerenderRows": 100,
     // The number nanoseconds between manual file reloads.
-	"reloadThreshold": 1000000000,
+    "reloadThreshold": 1000000000,
     // The maximum size of the file in bytes.
     // The rest of the file will be ignored.
-	"maxFileSizeBytes": 1073741824
+    "maxFileSizeBytes": 1073741824
 }

--- a/example.jlv.jsonc
+++ b/example.jlv.jsonc
@@ -62,5 +62,12 @@
         "40": "warn",
         "50": "error",
         "60": "fatal"
-    }
+    },
+    // The number of rows to pre-render.
+    "prerenderRows": 100,
+    // The number nanoseconds between manual file reloads.
+	"reloadThreshold": 1000000000,
+    // The maximum size of the file in bytes.
+    // The rest of the file will be ignored.
+	"maxFileSizeBytes": 1073741824
 }

--- a/internal/app/lazytable.go
+++ b/internal/app/lazytable.go
@@ -3,6 +3,7 @@ package app
 import (
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/hedhyw/json-log-viewer/internal/pkg/config"
 )
 

--- a/internal/app/lazytable.go
+++ b/internal/app/lazytable.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/hedhyw/json-log-viewer/internal/pkg/config"
+)
+
+// rowGetter renders the row.
+type rowGetter interface {
+	// Row return a rendered table row.
+	Row(cfg *config.Config) table.Row
+}
+
+// lazyTableModel lazily renders table rows.
+type lazyTableModel[T rowGetter] struct {
+	helper
+
+	table table.Model
+
+	minRenderedRows int
+	allEntries      []T
+	lastCursor      int
+
+	renderedRows []table.Row
+}
+
+// Init implements tea.Model.
+func (m lazyTableModel[T]) Init() tea.Cmd {
+	return nil
+}
+
+// View implements tea.Model.
+func (m lazyTableModel[T]) View() string {
+	return m.table.View()
+}
+
+// Update implements tea.Model.
+func (m lazyTableModel[T]) Update(msg tea.Msg) (lazyTableModel[T], tea.Cmd) {
+	var cmd tea.Cmd
+
+	m.table, cmd = m.table.Update(msg)
+
+	if m.table.Cursor() != m.lastCursor {
+		m = m.withRenderedRows()
+	}
+
+	return m, cmd
+}
+
+func (m lazyTableModel[T]) withRenderedRows() lazyTableModel[T] {
+	cursor := m.table.Cursor()
+
+	start := max(len(m.renderedRows), cursor)
+	end := min(cursor+m.minRenderedRows, len(m.allEntries))
+
+	for i := start; i < end; i++ {
+		m.renderedRows = append(m.renderedRows, m.allEntries[i].Row(m.Config))
+	}
+
+	m.table.SetRows(m.renderedRows)
+	m.lastCursor = m.table.Cursor()
+
+	return m
+}

--- a/internal/app/statefiltered.go
+++ b/internal/app/statefiltered.go
@@ -14,7 +14,7 @@ type StateFiltered struct {
 
 	previousState StateLoaded
 	table         logsTableModel
-	logEntries    source.LogEntries
+	logEntries    source.LazyLogEntries
 
 	filterText string
 	keys       KeyMap
@@ -89,7 +89,7 @@ func (s StateFiltered) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (s StateFiltered) handleLogEntriesLoadedMsg(
 	msg events.LogEntriesLoadedMsg,
 ) (tea.Model, tea.Cmd) {
-	s.logEntries = source.LogEntries(msg)
+	s.logEntries = source.LazyLogEntries(msg)
 	s.table = newLogsTableModel(s.Application, s.logEntries)
 
 	return s, s.table.Init()

--- a/internal/app/stateinitial.go
+++ b/internal/app/stateinitial.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/hedhyw/json-log-viewer/internal/pkg/events"
@@ -35,7 +37,7 @@ func (s StateInitial) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case events.ErrorOccuredMsg:
 		return s.handleErrorOccuredMsg(msg)
 	case events.LogEntriesLoadedMsg:
-		return s.handleLogEntriesLoadedMsg(msg)
+		return s.handleLogEntriesLoadedMsg(msg, time.UnixMilli(0))
 	case tea.KeyMsg:
 		return s, tea.Quit
 	default:

--- a/internal/app/stateloaded_test.go
+++ b/internal/app/stateloaded_test.go
@@ -180,7 +180,7 @@ goos: linux
 goarch: amd64
 pkg: github.com/hedhyw/json-log-viewer/internal/app
 cpu: 12th Gen Intel(R) Core(TM) i7-1255U
-BenchmarkStateLoadedBig-12    	16499398	        78.08 ns/op	     199 B/op	       0 allocs/op
+BenchmarkStateLoadedBig-12    	16499398	        78.08 ns/op	     199 B/op	       0 allocs/op.
 */
 func BenchmarkStateLoadedBig(b *testing.B) {
 	content := strings.Repeat(`{"time":"1970-01-01T00:00:00.00","level":"INFO","message": "test2"}`+"\n", b.N)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/hedhyw/jsoncjson"
@@ -21,6 +22,13 @@ type Config struct {
 	Fields []Field `json:"fields" validate:"min=1"`
 
 	CustomLevelMapping map[string]string `json:"customLevelMapping"`
+
+	// The number of rows to prerender.
+	PrerenderRows int `json:"prerenderRows"`
+	// ReloadThreshold is the minimum duration between reloading rows.
+	ReloadThreshold time.Duration `json:"reloadThreshold"`
+	// MaxFileSizeBytes is the maximum size of the file to load.
+	MaxFileSizeBytes int64 `json:"maxFileSizeBytes"`
 }
 
 // FieldKind describes the type of the log field.
@@ -51,6 +59,9 @@ func GetDefaultConfig() *Config {
 	return &Config{
 		Path:               "default",
 		CustomLevelMapping: GetDefaultCustomLevelMapping(),
+		PrerenderRows:      100,
+		ReloadThreshold:    time.Second,
+		MaxFileSizeBytes:   1024 * 1024 * 1024,
 		Fields: []Field{{
 			Title:      "Time",
 			Kind:       FieldKindNumericTime,

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -141,7 +141,10 @@ func ExampleGetDefaultConfig() {
 	// 		"40": "warn",
 	// 		"50": "error",
 	// 		"60": "fatal"
-	// 	}
+	// 	},
+	// 	"prerenderRows": 100,
+	// 	"reloadThreshold": 1000000000,
+	// 	"maxFileSizeBytes": 1073741824
 	// }
 }
 

--- a/internal/pkg/events/events.go
+++ b/internal/pkg/events/events.go
@@ -8,7 +8,7 @@ import (
 
 type (
 	// LogEntriesLoadedMsg is an event about successfully loaded log entries.
-	LogEntriesLoadedMsg source.LogEntries
+	LogEntriesLoadedMsg source.LazyLogEntries
 
 	// ErrorOccuredMsg is a generic error event.
 	ErrorOccuredMsg struct{ Err error }
@@ -17,7 +17,7 @@ type (
 	// for the given row.
 	OpenJSONRowRequestedMsg struct {
 		// LogEntries include all log entities.
-		LogEntries source.LogEntries
+		LogEntries source.LazyLogEntries
 
 		// Index of the row.
 		Index int
@@ -28,7 +28,7 @@ type (
 )
 
 // OpenJSONRowRequested implements tea.Cmd. It creates OpenJSONRowRequestedMsg.
-func OpenJSONRowRequested(logEntries source.LogEntries, index int) func() tea.Msg {
+func OpenJSONRowRequested(logEntries source.LazyLogEntries, index int) func() tea.Msg {
 	return func() tea.Msg {
 		return OpenJSONRowRequestedMsg{
 			LogEntries: logEntries,

--- a/internal/pkg/source/entry.go
+++ b/internal/pkg/source/entry.go
@@ -15,10 +15,12 @@ import (
 	"github.com/hedhyw/json-log-viewer/internal/pkg/config"
 )
 
+// LazyLogEntry holds unredenred LogEntry. Use `LogEntry` getter.
 type LazyLogEntry struct {
 	Line json.RawMessage
 }
 
+// LogEntry parses and returns `LogEntry`.
 func (e LazyLogEntry) LogEntry(cfg *config.Config) LogEntry {
 	return ParseLogEntry(e.Line, cfg)
 }

--- a/internal/pkg/source/entry_test.go
+++ b/internal/pkg/source/entry_test.go
@@ -211,36 +211,19 @@ func TestLogEntryRow(t *testing.T) {
 	assert.Equal(t, []string(row), entry.Fields)
 }
 
-func TestLogEntriesRows(t *testing.T) {
-	t.Parallel()
-
-	entries := source.LogEntries{
-		getFakeLogEntry(),
-		getFakeLogEntry(),
-		getFakeLogEntry(),
-	}
-	rows := entries.Rows()
-
-	if assert.Len(t, rows, len(entries)) {
-		for i, e := range entries {
-			assert.Equal(t, e.Row(), rows[i])
-		}
-	}
-}
-
-func TestLogEntriesReverse(t *testing.T) {
+func TestLazyLogEntriesReverse(t *testing.T) {
 	t.Parallel()
 
 	t.Run("simple", func(t *testing.T) {
 		t.Parallel()
 
-		original := source.LogEntries{
-			getFakeLogEntry(),
-			getFakeLogEntry(),
-			getFakeLogEntry(),
+		original := source.LazyLogEntries{
+			getFakeLazyLogEntry(),
+			getFakeLazyLogEntry(),
+			getFakeLazyLogEntry(),
 		}
 
-		entries := make(source.LogEntries, len(original))
+		entries := make(source.LazyLogEntries, len(original))
 		copy(entries, original)
 		actual := entries.Reverse()
 
@@ -252,8 +235,8 @@ func TestLogEntriesReverse(t *testing.T) {
 	t.Run("single", func(t *testing.T) {
 		t.Parallel()
 
-		entries := source.LogEntries{
-			getFakeLogEntry(),
+		entries := source.LazyLogEntries{
+			getFakeLazyLogEntry(),
 		}
 
 		assert.Len(t, entries, 1)
@@ -262,10 +245,16 @@ func TestLogEntriesReverse(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 
-		entries := source.LogEntries{}
+		entries := source.LazyLogEntries{}
 
 		assert.Empty(t, entries)
 	})
+}
+
+func getFakeLazyLogEntry() source.LazyLogEntry {
+	return source.LazyLogEntry{
+		Line: getFakeLogEntry().Line,
+	}
 }
 
 func getFakeLogEntry() source.LogEntry {
@@ -279,19 +268,18 @@ func getFakeLogEntry() source.LogEntry {
 	}
 }
 
-func TestLogEntriesFilter(t *testing.T) {
+func TestLazyLogEntriesFilter(t *testing.T) {
 	t.Parallel()
 
 	term := "special MESSAGE to search by in the test: " + t.Name()
 
-	logEntry := getFakeLogEntry()
-	logEntry.Fields = append(logEntry.Fields, term)
+	logEntry := getFakeLazyLogEntry()
 	logEntry.Line = json.RawMessage(`{"message": "` + term + `"}`)
 
-	logEntries := source.LogEntries{
-		getFakeLogEntry(),
+	logEntries := source.LazyLogEntries{
+		getFakeLazyLogEntry(),
 		logEntry,
-		getFakeLogEntry(),
+		getFakeLazyLogEntry(),
 	}
 
 	t.Run("all", func(t *testing.T) {

--- a/internal/pkg/source/source_test.go
+++ b/internal/pkg/source/source_test.go
@@ -53,3 +53,21 @@ func TestLoadLogsFromFile(t *testing.T) {
 		assert.NotEmpty(t, logEntries)
 	})
 }
+
+func TestLoadLogsFromFileLimited(t *testing.T) {
+	t.Parallel()
+
+	content := `{}`
+
+	testFile := tests.RequireCreateFile(t, []byte(content))
+
+	cfg := config.GetDefaultConfig()
+	cfg.MaxFileSizeBytes = 1
+
+	logEntries, err := source.LoadLogsFromFile(testFile, cfg)
+	require.NoError(t, err)
+
+	if assert.Len(t, logEntries, 1) {
+		assert.Equal(t, content[:cfg.MaxFileSizeBytes], string(logEntries[0].Line))
+	}
+}

--- a/internal/pkg/tests/tests.go
+++ b/internal/pkg/tests/tests.go
@@ -23,7 +23,11 @@ func RequireCreateFile(tb testing.TB, content []byte) string {
 	require.NoError(tb, err)
 
 	name := f.Name()
-	tb.Cleanup(func() { assert.NoError(tb, os.Remove(name)) })
+	tb.Cleanup(func() {
+		if _, err := os.Stat(name); err == nil {
+			assert.NoError(tb, os.Remove(name))
+		}
+	})
 
 	return name
 }


### PR DESCRIPTION
1. Parse only 100 rows after the current cursor (by config).
2. Add threshold between file reloads -> 1s (by config).
3. Limit the maximum size of the file -> 1 GB (by config).
4. Trigger garbage collector after file reloading.
5. Add benchmark test.