### PR TITLE
feat: support filtering by field

### DIFF
--- a/internal/app/statefiltered.go
+++ b/internal/app/statefiltered.go
@@ -102,7 +102,7 @@ func (s StateFilteredModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (s StateFilteredModel) handleStateFilteredModel() (StateFilteredModel, tea.Msg) {
-	entries, err := s.Application.Entries().Filter(s.filterField, s.filterText, s.Config)
+	entries, err := s.Application.Entries().Filter(s.filterText, s.filterField, s.Config)
 	if err != nil {
 		return s, events.ShowError(err)()
 	}

--- a/internal/app/statefiltered_test.go
+++ b/internal/app/statefiltered_test.go
@@ -39,7 +39,7 @@ func TestStateFiltered(t *testing.T) {
 		})
 
 		lines := strings.Split(model.View(), "\n")
-		assert.Contains(t, lines[len(lines)-1], ">")
+		assert.Contains(t, lines[len(lines)-2], ">")
 
 		_, ok := model.(app.StateFilteringModel)
 		assert.Truef(t, ok, "%s", model)

--- a/internal/app/statefiltering.go
+++ b/internal/app/statefiltering.go
@@ -23,13 +23,12 @@ type StateFilteringModel struct {
 func newStateFiltering(
 	previousState StateLoadedModel,
 ) StateFilteringModel {
-
-	var s []string
-	for _, f := range previousState.Config.Fields {
-		s = append(s, f.Title)
+	fieldTitles := make([]string, len(previousState.Config.Fields))
+	for i, f := range previousState.Config.Fields {
+		fieldTitles[i] = f.Title
 	}
 
-	textInput := widgets.NewPillInputModel(s)
+	textInput := widgets.NewPillInputModel(fieldTitles)
 	textInput.Focus()
 
 	return StateFilteringModel{

--- a/internal/pkg/source/entry.go
+++ b/internal/pkg/source/entry.go
@@ -91,7 +91,7 @@ func (entries LazyLogEntries) Len() int {
 }
 
 // Filter filters entries by ignore case exact match.
-func (entries LazyLogEntries) Filter(fieldName string, term string, c *config.Config) (LazyLogEntries, error) {
+func (entries LazyLogEntries) Filter(term string, fieldName string, c *config.Config) (LazyLogEntries, error) {
 	if term == "" {
 		return entries, nil
 	}

--- a/internal/pkg/source/entry_test.go
+++ b/internal/pkg/source/entry_test.go
@@ -339,26 +339,27 @@ func TestLazyLogEntriesFilter(t *testing.T) {
 func TestLazyLogEntriesFieldFilter(t *testing.T) {
 	t.Parallel()
 
-	term := "level:info"
+	const term = "info"
 
-	logs := `
+	const logs = `
 {"level":"info","time":"2025-12-16T13:20:00-05:00","message":"2025-12-16 13:20:00.049  Day1|  Ana went home!"}
 {"level":"debug","time":"2025-12-16T13:20:00-05:00","message":"2025-12-16 13:21:00.049  Day2| Tom was daydreaming"}
 {"level":"error","time":"2025-12-16T13:20:00-05:00","message":"2025-12-16 13:22:00.049  Day3| Can't wait to be weekend!"}
 `
 
-	c := config.GetDefaultConfig()
+	defaultConfig := config.GetDefaultConfig()
 
 	createEntries := func(tb testing.TB) (source.LazyLogEntries, source.LazyLogEntry) {
-		source, err := source.Reader(bytes.NewReader([]byte(logs)), config.GetDefaultConfig())
-		require.NoError(t, err)
+		tb.Helper()
+		source, err := source.Reader(bytes.NewReader([]byte(logs)), defaultConfig)
+		require.NoError(tb, err)
 
 		tb.Cleanup(func() { assert.NoError(tb, source.Close()) })
 
 		logEntries, err := source.ParseLogEntries()
-		require.NoError(t, err)
+		require.NoError(tb, err)
 
-		logEntry := logEntries.Entries[1]
+		logEntry := logEntries.Entries[0]
 
 		return logEntries, logEntry
 	}
@@ -368,7 +369,7 @@ func TestLazyLogEntriesFieldFilter(t *testing.T) {
 
 		logEntries, logEntry := createEntries(t)
 
-		filtered, err := logEntries.Filter(term, "", c)
+		filtered, err := logEntries.Filter(term, "level", defaultConfig)
 		require.NoError(t, err)
 
 		if assert.Len(t, filtered.Entries, 1) {

--- a/internal/pkg/widgets/pillinput.go
+++ b/internal/pkg/widgets/pillinput.go
@@ -10,7 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// PillInputModel is a widget that allows inputting text with optional prefix selected from autocomplete suggestion
+// PillInputModel is a widget that allows inputting text with optional prefix selected from autocomplete suggestion.
 type PillInputModel struct {
 	textInput     textinput.Model
 	help          help.Model
@@ -57,9 +57,8 @@ func (m PillInputModel) Init() tea.Cmd {
 }
 
 func (m PillInputModel) Update(msg tea.Msg) (PillInputModel, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.Type {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.Type {
 		case tea.KeyTab:
 			if m.textInput.ShowSuggestions && len(m.textInput.AvailableSuggestions()) > 0 {
 				m.filterField = m.textInput.CurrentSuggestion()

--- a/internal/pkg/widgets/pillinput.go
+++ b/internal/pkg/widgets/pillinput.go
@@ -1,0 +1,133 @@
+package widgets
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// PillInputModel is a widget that allows inputting text with optional prefix selected from autocomplete suggestion
+type PillInputModel struct {
+	textInput     textinput.Model
+	help          help.Model
+	keymap        inputKeymap
+	filterField   string   // e.g., "level"
+	isPillVisible bool     // true if a field is selected
+	suggestions   []string // pill suggestions
+}
+
+// NewPillInputModel initializes a new PillInputModel with the given text.
+// It updates a widget with the message `tea.WindowSizeMsg`.
+func NewPillInputModel(suggestions []string) PillInputModel {
+	ti := textinput.New()
+	ti.Placeholder = "Field name or search term..."
+	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+	ti.Focus()
+	ti.ShowSuggestions = true
+	ti.SetSuggestions(suggestions)
+
+	h := help.New()
+
+	km := inputKeymap{}
+
+	return PillInputModel{textInput: ti, help: h, keymap: km, isPillVisible: false, filterField: "", suggestions: suggestions}
+}
+
+type inputKeymap struct{}
+
+func (k inputKeymap) ShortHelp() []key.Binding {
+	return []key.Binding{
+		key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "complete")),
+		key.NewBinding(key.WithKeys("down", "ctrl+n"), key.WithHelp("(↓, ctrl+n)", "next")),
+		key.NewBinding(key.WithKeys("up", "ctrl+p"), key.WithHelp("(↑, ctrl+p)", "prev")),
+		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "quit")),
+	}
+}
+
+func (k inputKeymap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{k.ShortHelp()}
+}
+
+func (m PillInputModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m PillInputModel) Update(msg tea.Msg) (PillInputModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyTab:
+			if m.textInput.ShowSuggestions && len(m.textInput.AvailableSuggestions()) > 0 {
+				m.filterField = m.textInput.CurrentSuggestion()
+				m.isPillVisible = true
+
+				// 1. Reset the input buffer completely
+				m.textInput.Reset()
+				m.textInput.SetValue("")
+				m.textInput.SetSuggestions([]string{})
+				m.textInput.Placeholder = "Search term..."
+
+				// 2. Disable suggestions for the "Value" phase
+				m.textInput.ShowSuggestions = false
+
+				// 3. IMPORTANT: Return nil to stop the tab key from
+				// being passed to the textinput.Update(msg) below.
+				return m, nil
+			}
+
+		case tea.KeyBackspace:
+			// If input is empty and a pill is active, jump back to field selection
+			if m.textInput.Value() == "" && m.isPillVisible {
+				m.isPillVisible = false
+				m.textInput.Reset()
+				m.textInput.SetValue(m.filterField)
+				m.textInput.CursorEnd()
+				m.filterField = "" // Clear the filter field when going back
+
+				// Re-enable suggestions for the "Field" phase
+				m.textInput.ShowSuggestions = true
+				m.textInput.SetSuggestions(m.suggestions)
+				return m, nil
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+	// Only update the input if we didn't handle a mode-switch above
+	m.textInput, cmd = m.textInput.Update(msg)
+	return m, cmd
+}
+
+var pillStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.Color("229")).
+	Background(lipgloss.Color("57")). // Purple background
+	Padding(0, 1).
+	MarginRight(1).
+	Bold(true)
+
+func (m PillInputModel) View() string {
+	var s strings.Builder
+
+	if m.isPillVisible {
+		// Render the Pill
+		pill := pillStyle.Render(m.filterField + ":")
+		s.WriteString(pill)
+	}
+
+	// Render the input
+	s.WriteString(m.textInput.View())
+
+	return s.String() + "\n" + m.help.View(m.keymap)
+}
+
+func (m PillInputModel) Focus() tea.Cmd {
+	return m.textInput.Focus()
+}
+
+func (m PillInputModel) Value() (string, string) {
+	return m.filterField, m.textInput.Value()
+}

--- a/internal/pkg/widgets/pillinput_test.go
+++ b/internal/pkg/widgets/pillinput_test.go
@@ -31,7 +31,7 @@ func TestPillInputModelInit(t *testing.T) {
 	model := widgets.NewPillInputModel(suggestions)
 
 	cmd := model.Init()
-	assert.NotNil(t, cmd, "Init should return a focus command")
+	assert.Nil(t, cmd, "Init should return nil command")
 }
 
 func TestPillInputModelView(t *testing.T) {

--- a/internal/pkg/widgets/pillinput_test.go
+++ b/internal/pkg/widgets/pillinput_test.go
@@ -1,0 +1,229 @@
+package widgets_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hedhyw/json-log-viewer/internal/pkg/widgets"
+)
+
+func TestNewPillInputModel(t *testing.T) {
+	t.Parallel()
+
+	suggestions := []string{"level", "message", "timestamp"}
+	model := widgets.NewPillInputModel(suggestions)
+
+	assert.NotNil(t, model)
+
+	// Verify initial state
+	filterField, value := model.Value()
+	assert.Empty(t, filterField, "filter field should be empty initially")
+	assert.Empty(t, value, "value should be empty initially")
+}
+
+func TestPillInputModelInit(t *testing.T) {
+	t.Parallel()
+
+	suggestions := []string{"level", "message"}
+	model := widgets.NewPillInputModel(suggestions)
+
+	cmd := model.Init()
+	assert.NotNil(t, cmd, "Init should return a focus command")
+}
+
+func TestPillInputModelView(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without_pill", func(t *testing.T) {
+		t.Parallel()
+
+		suggestions := []string{"level", "message"}
+		model := widgets.NewPillInputModel(suggestions)
+
+		view := model.View()
+		assert.NotEmpty(t, view)
+		// Should not contain pill styling when no field is selected
+		assert.NotContains(t, view, "level:")
+		assert.NotContains(t, view, "message:")
+	})
+
+	t.Run("with_pill", func(t *testing.T) {
+		t.Parallel()
+
+		suggestions := []string{"level", "message"}
+		model := widgets.NewPillInputModel(suggestions)
+
+		// Type "lev" to get "level" suggestion
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+
+		// Press Tab to select suggestion
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+		view := model.View()
+		assert.NotEmpty(t, view)
+		// Should contain pill with selected field
+		assert.Contains(t, view, "level:")
+	})
+}
+
+func TestPillInputModelUpdateTabKey(t *testing.T) {
+	t.Parallel()
+
+	suggestions := []string{"level", "message", "timestamp"}
+	model := widgets.NewPillInputModel(suggestions)
+
+	// Type "lev" to match "level"
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+
+	// Press Tab to select the suggestion
+	model, cmd := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	// Verify pill is visible
+	filterField, value := model.Value()
+	assert.Equal(t, "level", filterField, "filter field should be set to selected suggestion")
+	assert.Empty(t, value, "value should be empty after selecting field")
+	assert.Nil(t, cmd, "Tab should not return a command when selecting suggestion")
+}
+
+func TestPillInputModelUpdateBackspace(t *testing.T) {
+	t.Parallel()
+
+	suggestions := []string{"level", "message"}
+	model := widgets.NewPillInputModel(suggestions)
+
+	// Type and select a suggestion
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	// Verify pill is active
+	filterField, _ := model.Value()
+	require.Equal(t, "level", filterField)
+
+	// Press backspace when input is empty to go back to field selection
+	model, cmd := model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+
+	// Verify we're back to field selection mode
+	filterField, value := model.Value()
+	assert.Empty(t, filterField, "filter field should be cleared")
+	assert.Equal(t, "level", value, "value should contain the previous filter field")
+	assert.Nil(t, cmd, "Backspace should not return a command when going back")
+}
+
+func TestPillInputModelUpdateTextInput(t *testing.T) {
+	t.Parallel()
+
+	suggestions := []string{"level", "message"}
+	model := widgets.NewPillInputModel(suggestions)
+
+	// Type some text
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+
+	_, value := model.Value()
+	assert.Equal(t, "test", value, "value should contain typed text")
+}
+
+func TestPillInputModelValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no_pill_selected", func(t *testing.T) {
+		t.Parallel()
+
+		suggestions := []string{"level"}
+		model := widgets.NewPillInputModel(suggestions)
+
+		// Type some text without selecting a field
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+
+		filterField, value := model.Value()
+		assert.Empty(t, filterField, "filter field should be empty")
+		assert.Equal(t, "te", value, "value should contain typed text")
+	})
+
+	t.Run("pill_selected_with_value", func(t *testing.T) {
+		t.Parallel()
+
+		suggestions := []string{"level"}
+		model := widgets.NewPillInputModel(suggestions)
+
+		// Select field
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+		// Type value
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+
+		filterField, value := model.Value()
+		assert.Equal(t, "level", filterField, "filter field should be set")
+		assert.Equal(t, "er", value, "value should contain typed text after pill")
+	})
+}
+
+func TestPillInputModelFocus(t *testing.T) {
+	t.Parallel()
+
+	suggestions := []string{"level"}
+	model := widgets.NewPillInputModel(suggestions)
+
+	cmd := model.Focus()
+	assert.NotNil(t, cmd, "Focus should return a command")
+}
+
+func TestPillInputModelCompleteWorkflow(t *testing.T) {
+	t.Parallel()
+
+	suggestions := []string{"level", "message", "timestamp"}
+	model := widgets.NewPillInputModel(suggestions)
+
+	// Step 1: Type to filter suggestions
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+
+	// Step 2: Select suggestion with Tab
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	filterField, value := model.Value()
+	assert.Equal(t, "message", filterField)
+	assert.Empty(t, value)
+
+	// Step 3: Type the filter value
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+
+	filterField, value = model.Value()
+	assert.Equal(t, "message", filterField)
+	assert.Equal(t, "err", value)
+
+	// Step 4: Verify view contains pill
+	view := model.View()
+	assert.Contains(t, view, "message:")
+
+	// Step 5: Backspace all the way back
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+
+	// Should still have pill
+	filterField, value = model.Value()
+	assert.Equal(t, "message", filterField)
+	assert.Empty(t, value)
+
+	// One more backspace should remove pill
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+
+	filterField, value = model.Value()
+	assert.Empty(t, filterField)
+	assert.Equal(t, "message", value)
+}

--- a/internal/pkg/widgets/plain.go
+++ b/internal/pkg/widgets/plain.go
@@ -37,15 +37,15 @@ func NewPlainLogModel(
 	return m, cmd
 }
 
-// Init implements team.Model interface.
+// Init implements tea.Model interface.
 func (m PlainLogModel) Init() tea.Cmd { return nil }
 
-// View implements team.Model interface.
+// View implements tea.Model interface.
 func (m PlainLogModel) View() string {
 	return m.viewport.View()
 }
 
-// Update implements team.Model interface.
+// Update implements tea.Model interface.
 func (m PlainLogModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// nolint: gocritic // For future extension.
 	switch msg := msg.(type) {


### PR DESCRIPTION
Fixes https://github.com/hedhyw/json-log-viewer/issues/18

This adds new input field to the statefiltering screen. When user starts to type the search term, first an autocomplete over all defined fields is provided (this is built autocomplete from bubbletea). If user confirm the field selection with Tab, this field is locked as a "pill". User can proceed with the actual search term.

If the field is not confirmed, the whole input is treated as search term, preserving original functionality.

![field-filter](https://github.com/user-attachments/assets/b01d8bc9-bdba-4390-b3f9-2a72cf2dfff2)
