### PR TITLE
feat: when returning from search, keep the search term under cursor

### DIFF
--- a/internal/app/lazytable.go
+++ b/internal/app/lazytable.go
@@ -195,6 +195,28 @@ func (m lazyTableModel) viewPortCursor() int {
 	return m.offset + m.table.Cursor()
 }
 
+func (m lazyTableModel) Select(index int) lazyTableModel {
+	if index < 0 || index >= m.entries.Len() {
+		return m
+	}
+
+	m.follow = false
+
+	height := max(m.table.Height(), 1)
+	maxOffset := max(m.entries.Len()-height, 0)
+	m.offset = min(max(index-height/2, 0), maxOffset)
+
+	viewSize := m.viewPortEnd() - m.viewPortStart()
+	cursor := index - m.offset
+	if m.reverse {
+		cursor = viewSize - 1 - cursor
+	}
+
+	m.table.SetCursor(cursor)
+
+	return m.RenderedRows()
+}
+
 func (m lazyTableModel) viewPortStart() int {
 	return m.offset
 }

--- a/internal/app/logstable.go
+++ b/internal/app/logstable.go
@@ -104,3 +104,9 @@ func (m logsTableModel) handleWindowSizeMsg(msg tea.WindowSizeMsg) logsTableMode
 func (m logsTableModel) Cursor() int {
 	return m.lazyTable.viewPortCursor()
 }
+
+func (m logsTableModel) Select(index int) logsTableModel {
+	m.lazyTable = m.lazyTable.Select(index)
+
+	return m
+}

--- a/internal/app/statefiltered.go
+++ b/internal/app/statefiltered.go
@@ -91,7 +91,7 @@ func (s StateFilteredModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (s StateFilteredModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, s.keys.Back):
-		return s.previousState.refresh()
+		return s.handleBackKeyClickedMsg()
 	case key.Matches(msg, s.keys.Filter):
 		return s.handleFilterKeyClickedMsg()
 	case key.Matches(msg, s.keys.ToggleViewArrow), key.Matches(msg, s.keys.Open):
@@ -99,6 +99,16 @@ func (s StateFilteredModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	default:
 		return nil, nil
 	}
+}
+
+func (s StateFilteredModel) handleBackKeyClickedMsg() (tea.Model, tea.Cmd) {
+	cursor := s.table.Cursor()
+	if cursor >= 0 && cursor < s.logEntries.Len() {
+		entry := s.logEntries.LogEntry(s.Config, cursor)
+		s.previousState.table = s.previousState.table.Select(entry.Index)
+	}
+
+	return s.previousState.refresh()
 }
 
 func (s StateFilteredModel) handleStateFilteredModel() (StateFilteredModel, tea.Msg) {

--- a/internal/app/statefiltered_test.go
+++ b/internal/app/statefiltered_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 
 	"github.com/hedhyw/json-log-viewer/internal/app"
+	"github.com/hedhyw/json-log-viewer/internal/pkg/config"
 	"github.com/hedhyw/json-log-viewer/internal/pkg/events"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStateFiltered(t *testing.T) {
@@ -130,6 +132,40 @@ func TestStateFiltered(t *testing.T) {
 
 		_, ok := model.(app.StateLoadedModel)
 		assert.Truef(t, ok, "%s", model)
+	})
+
+	t.Run("returned_to_selected_entry", func(t *testing.T) {
+		t.Parallel()
+
+		const jsonFile = `
+		{"time":"1970-01-01T00:00:00.00","level":"INFO","message":"tail"}
+		{"time":"1970-01-01T00:00:00.00","level":"INFO","message":"included 1"}
+		{"time":"1970-01-01T00:00:00.00","level":"INFO","message":"other"}
+		{"time":"1970-01-01T00:00:00.00","level":"INFO","message":"included 2"}
+		{"time":"1970-01-01T00:00:00.00","level":"INFO","message":"end"}
+		`
+
+		model := newTestModel(t, []byte(jsonFile), func(cfg *config.Config) {
+			cfg.IsReverseDefault = false
+		})
+
+		model = handleUpdate(model, tea.KeyMsg{
+			Type:  tea.KeyRunes,
+			Runes: []rune{'f'},
+		})
+		model = handleUpdate(model, tea.KeyMsg{
+			Type:  tea.KeyRunes,
+			Runes: []rune("included"),
+		})
+		model = handleUpdate(model, tea.KeyMsg{Type: tea.KeyEnter})
+		model = handleUpdate(model, tea.KeyMsg{Type: tea.KeyDown})
+		model = handleUpdate(model, tea.KeyMsg{Type: tea.KeyEsc})
+		model = handleUpdate(model, tea.KeyMsg{Type: tea.KeyEnter})
+
+		_, ok := model.(app.StateViewRowModel)
+		require.Truef(t, ok, "%s", model)
+		assert.Contains(t, model.View(), "included 2")
+		assert.NotContains(t, model.View(), "end")
 	})
 
 	t.Run("stringer", func(t *testing.T) {

--- a/internal/pkg/source/entry.go
+++ b/internal/pkg/source/entry.go
@@ -26,6 +26,7 @@ const (
 type LazyLogEntry struct {
 	offset int64
 	length int
+	index  int
 }
 
 // Length of the entry.
@@ -50,15 +51,20 @@ func (e LazyLogEntry) LogEntry(file *os.File, cfg *config.Config) LogEntry {
 	line, err := e.Line(file)
 	if err != nil {
 		return LogEntry{
+			Index: e.index,
 			Error: err,
 		}
 	}
 
-	return parseLogEntry(line, cfg)
+	entry := parseLogEntry(line, cfg)
+	entry.Index = e.index
+
+	return entry
 }
 
 // LogEntry is a single partly-parse record of the log.
 type LogEntry struct {
+	Index  int
 	Fields []string
 	Line   json.RawMessage
 	Error  error

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -135,6 +135,7 @@ func (s *Source) ParseLogEntries() (LazyLogEntries, error) {
 			return LazyLogEntries{}, err
 		}
 
+		entry.index = len(logEntries)
 		logEntries = append(logEntries, entry)
 	}
 

--- a/internal/pkg/source/source_test.go
+++ b/internal/pkg/source/source_test.go
@@ -54,6 +54,24 @@ func TestParseLogEntries(t *testing.T) {
 		assert.NotEmpty(t, logEntries)
 	})
 
+	t.Run("log_entry_index", func(t *testing.T) {
+		t.Parallel()
+
+		reader := strings.NewReader("\n{\"message\":\"first\"}\n\n{\"message\":\"second\"}\n")
+
+		source, err := source.Reader(reader, config.GetDefaultConfig())
+		require.NoError(t, err)
+
+		t.Cleanup(func() { assert.NoError(t, source.Close()) })
+
+		logEntries, err := source.ParseLogEntries()
+		require.NoError(t, err)
+
+		require.Equal(t, 2, logEntries.Len())
+		assert.Equal(t, 0, logEntries.LogEntry(config.GetDefaultConfig(), 0).Index)
+		assert.Equal(t, 1, logEntries.LogEntry(config.GetDefaultConfig(), 1).Index)
+	})
+
 	t.Run("failed", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/pkg/source/steamer.go
+++ b/internal/pkg/source/steamer.go
@@ -107,6 +107,7 @@ func (s *Source) readLogEntries(
 		}
 
 		logEntriesLock.Lock()
+		entry.index = len(*logEntries)
 		*logEntries = append(*logEntries, entry)
 		logEntriesLock.Unlock()
 	}

--- a/internal/pkg/source/streamer_test.go
+++ b/internal/pkg/source/streamer_test.go
@@ -111,6 +111,52 @@ func TestStartStreamingUpdates(t *testing.T) {
 	}
 }
 
+func TestStartStreamingLogEntryIndex(t *testing.T) {
+	t.Parallel()
+
+	pipeReader, pipeWriter := io.Pipe()
+
+	t.Cleanup(func() {
+		assert.NoError(t, pipeReader.Close())
+		assert.NoError(t, pipeWriter.Close())
+	})
+
+	cfg := config.GetDefaultConfig()
+
+	inputSource, err := source.Reader(pipeReader, cfg)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { assert.NoError(t, inputSource.Close()) })
+
+	ctx := tests.Context(t)
+
+	entries := make(chan source.LazyLogEntries)
+
+	inputSource.StartStreaming(ctx, func(msg source.LazyLogEntries, _ error) {
+		if msg.Len() < 2 {
+			return
+		}
+
+		select {
+		case entries <- msg:
+		case <-ctx.Done():
+		}
+	})
+
+	_, err = fmt.Fprintln(pipeWriter, `{"message":"first"}`)
+	require.NoError(t, err)
+	_, err = fmt.Fprintln(pipeWriter, `{"message":"second"}`)
+	require.NoError(t, err)
+
+	select {
+	case msg := <-entries:
+		assert.Equal(t, 0, msg.LogEntry(cfg, 0).Index)
+		assert.Equal(t, 1, msg.LogEntry(cfg, 1).Index)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+}
+
 func TestStartStreamingContextClosed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Implements #162 

When returning from filter view, the selected message is highlighted in the unfiltered view.