### PR TITLE
ci: release with built-in token, PAT only for brew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,4 +28,5 @@ jobs:
           version: '~> v2'
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,6 +60,7 @@ brews:
     repository:
       owner: hedhyw
       name: homebrew-main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     test: system "#{bin}/jlv", "-help"
     install: |-
       bin.install "jlv"


### PR DESCRIPTION
Same hardening as otelinji#140 / gherkingen#137 (release here still works, but only until `GH_PAT` expires):

- GitHub release now uses the built-in `GITHUB_TOKEN` — no PAT needed
- `GH_PAT` only used for the homebrew-main formula push

No action required after merge; PAT expiry will no longer break releases.